### PR TITLE
add ignore empty line to no-eol-whitespace

### DIFF
--- a/linters/stylelint.config.js
+++ b/linters/stylelint.config.js
@@ -4,7 +4,12 @@ module.exports = {
         "indentation": 4,
         "string-quotes": "double",
         "max-empty-lines": 1,
-        "no-eol-whitespace": true,
+        "no-eol-whitespace": [
+            true,
+            {
+                ignore: ["empty-lines"]
+            }
+        ],
         "no-missing-end-of-source-newline": true,
         // Block
         "block-no-empty": true,


### PR DESCRIPTION
Улучшил стайл линт правило 
теперь в случае когда в scss файле делаешь отступ на втором уровне между блоками селекторов стайл линт не ругается на лишние пробелы:

![image](https://user-images.githubusercontent.com/4182293/41402964-581503be-6fcc-11e8-918b-1f8d6cecad9a.png)
