### PR TITLE
remove no-underscore-property property which is unimplemented in tslint

### DIFF
--- a/linters/tslint.json
+++ b/linters/tslint.json
@@ -2,7 +2,6 @@
   "rulesDirectory": "ts-rules",
   "rules": {
     "strict-alias-import": [true, "ui-kit"],
-    "no-underscore-property": true,
     "class-name": true,
     "comment-format": [
       true,


### PR DESCRIPTION
Короче там быстрее было поправить, чем создавать ишак, просто такого правила нет и я его убрал

или глянуть тут:
https://palantir.github.io/tslint/rules/variable-name/

но кажется оно не поможет