### PR TITLE
process.env.NODE_ENV now visible in client code

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -83,7 +83,11 @@ function runCommand(_command) {
         ? path.resolve(PROJECT_ROOT_PATH, workdir)
         : PROJECT_ROOT_PATH;
 
-    const webpackConfig = BuildConfigGenerator.makeBuildConfig(buildProfile, buildWorkdir, PROJECT_NODE_MODULES_PATH);
+    const webpackConfig = BuildConfigGenerator.makeBuildConfig(
+        buildProfile,
+        buildWorkdir,
+        PROJECT_NODE_MODULES_PATH,
+    );
 
     const runBuildCommand = require(`./commands/${_command}.js`);
     runBuildCommand(webpackConfig, {

--- a/webpack/config-generator.js
+++ b/webpack/config-generator.js
@@ -29,7 +29,7 @@ class WebpackConfigGenerator {
         });
 
         // eslint-disable-next-line global-require
-        const profileConfig = require(`./profiles/${normalizedProfileName}`)(this.projectSettings);
+        const profileConfig = require(`./profiles/${normalizedProfileName}`)(this.projectSettings, profileName);
 
         // Build config in webpack format
         const webpackConfig = Object.assign(baseWebpackConfig, {

--- a/webpack/profiles/dev.js
+++ b/webpack/profiles/dev.js
@@ -6,7 +6,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const configValidator = require("../../config/validator");
 
 function makeConfig(projectConfig, profileName) {
-    const profileVariables = projectConfig.profiles.dev;
+    const profileVariables = projectConfig.profiles[profileName];
     const { indexFilePath, projectRoot, buildPath } = projectConfig;
 
     const htmlWebpackOptions = {
@@ -14,7 +14,7 @@ function makeConfig(projectConfig, profileName) {
         hash: true,
         template: "index.ejs",
         profileVariables,
-        envName: "dev",
+        envName: profileName,
     };
 
     if (indexFilePath) {
@@ -30,12 +30,12 @@ function makeConfig(projectConfig, profileName) {
             tsconfig: path.resolve(projectRoot, "tsconfig.json"),
         }),
         new ExtractTextPlugin({
-            filename: "dev.[name].bundle.css",
+            filename: `${profileName}.[name].bundle.css`,
             allChunks: true,
         }),
         new HtmlWebpackPlugin(htmlWebpackOptions),
         new Webpack.SourceMapDevToolPlugin({
-            filename: "dev.[name].js.map",
+            filename: `${profileName}.[name].js.map`,
             exclude: [/vendor/, /.css/],
         }),
         new Webpack.DefinePlugin({
@@ -55,8 +55,8 @@ function makeConfig(projectConfig, profileName) {
     return {
         webpackDevtool: "eval-source-map",
         webpackOutputSettings: {
-            filename: "dev.[name].bundle.js",
-            chunkFilename: "dev.chunk.[name].js",
+            filename: `${profileName}.[name].bundle.js`,
+            chunkFilename: `${profileName}.chunk.[name].js`,
         },
         // WARNING! Be careful, this object overrides the default plugins section
         // so don't put the plugins to the base config

--- a/webpack/profiles/dev.js
+++ b/webpack/profiles/dev.js
@@ -5,7 +5,7 @@ const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const configValidator = require("../../config/validator");
 
-function makeConfig(projectConfig) {
+function makeConfig(projectConfig, profileName) {
     const profileVariables = projectConfig.profiles.dev;
     const { indexFilePath, projectRoot, buildPath } = projectConfig;
 
@@ -37,6 +37,9 @@ function makeConfig(projectConfig) {
         new Webpack.SourceMapDevToolPlugin({
             filename: "dev.[name].js.map",
             exclude: [/vendor/, /.css/],
+        }),
+        new Webpack.DefinePlugin({
+            "process.env.NODE_ENV": JSON.stringify(profileName),
         }),
     ];
 

--- a/webpack/profiles/production.js
+++ b/webpack/profiles/production.js
@@ -10,7 +10,7 @@ const configValidator = require("../../config/validator");
 const path = require("path");
 
 function makeConfig(projectConfig, profileName) {
-    const profileVariables = projectConfig.profiles.production;
+    const profileVariables = projectConfig.profiles[profileName];
     const { indexFilePath, projectRoot, buildPath } = projectConfig;
 
 
@@ -26,7 +26,7 @@ function makeConfig(projectConfig, profileName) {
         },
         template: "index.ejs",
         profileVariables,
-        envName: "production",
+        envName: profileName,
     };
 
     if (indexFilePath) {

--- a/webpack/profiles/production.js
+++ b/webpack/profiles/production.js
@@ -9,7 +9,7 @@ const CleanWebpackPlugin = require("clean-webpack-plugin");
 const configValidator = require("../../config/validator");
 const path = require("path");
 
-function makeConfig(projectConfig) {
+function makeConfig(projectConfig, profileName) {
     const profileVariables = projectConfig.profiles.production;
     const { indexFilePath, projectRoot, buildPath } = projectConfig;
 
@@ -69,7 +69,7 @@ function makeConfig(projectConfig) {
                 parallel: true,
             }),
             new Webpack.DefinePlugin({
-                "process.env.NODE_ENV": JSON.stringify("production"),
+                "process.env.NODE_ENV": JSON.stringify(profileName),
             }),
             new CleanWebpackPlugin(buildPath, {
                 allowExternal: true,

--- a/webpack/profiles/staging.js
+++ b/webpack/profiles/staging.js
@@ -1,7 +1,7 @@
 const productionConfigGenerator = require("./production");
 
-function makeConfig(projectConfig) {
-    const config = productionConfigGenerator(projectConfig);
+function makeConfig(projectConfig, profileName) {
+    const config = productionConfigGenerator(projectConfig, profileName);
     config.webpackDevtool = "source-map";
     return config;
 }

--- a/webpack/profiles/test.js
+++ b/webpack/profiles/test.js
@@ -2,12 +2,16 @@ const path = require("path");
 const environment = require("../../environment");
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
+const Webpack = require("webpack");
 
-function makePlugins(projectConfig) {
+function makePlugins(projectConfig, profileName) {
     const plugins = [
         new ExtractTextPlugin({
             filename: "test/[name].bundle.css",
             allChunks: true,
+        }),
+        new Webpack.DefinePlugin({
+            "process.env.NODE_ENV": JSON.stringify(profileName),
         }),
     ];
 


### PR DESCRIPTION
Now you can use process.env.NODE_ENV in your code to compile/skip environment-specific code parts

Example:
```typescript
if (process.env.NODE_ENV === "dev") {
   alert("You're in DEV mode!");
}
```