### PR TITLE
Trailing whitespace

### DIFF
--- a/linters/tslint.json
+++ b/linters/tslint.json
@@ -43,7 +43,7 @@
         "singleline": "never"
       }
     ],
-    "no-trailing-whitespace": false,
+    "no-trailing-whitespace": [true, "ignore-template-strings", "ignore-comments", "ignore-blank-lines"],
     "no-unused-expression": true,
     "no-var-keyword": true,
     "new-parens": true,


### PR DESCRIPTION
After TSlint was updated, we can (and must) configure trailing-whitespace prop more accurate