### PR TITLE
Store build artifacts in the separate folder (except index.html)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ module.exports = {
         // Here you can override DevServer's settings.
         // FFBT proxies this object directly to the Webpack config
         // More info: https://webpack.js.org/configuration/dev-server
-    }
+    },
+    moveBuildArtifactsToSubfolder: "build" // you can move your compiled js, css and images to the subdirectory
 };
 ```
 

--- a/config/helpers.js
+++ b/config/helpers.js
@@ -1,6 +1,12 @@
 function getArtifactsDirectory(config, absolute = false) {
-    const absBuildPath = absolute ? config.buildPath : "";
-    const artifactsDirName = `${config.moveBuildArtifactsToSubfolder}/` || "";
+    const absBuildPath = absolute
+        ? `${config.buildPath}/`
+        : "";
+
+    const artifactsDirName = config.moveBuildArtifactsToSubfolder
+        ? `${config.moveBuildArtifactsToSubfolder}/`
+        : "";
+
     return absBuildPath + artifactsDirName;
 }
 

--- a/config/helpers.js
+++ b/config/helpers.js
@@ -1,0 +1,14 @@
+function getArtifactsDirectory(config, absolute = false) {
+    const absBuildPath = absolute ? config.buildPath : "";
+    const artifactsDirName = `${config.moveBuildArtifactsToSubfolder}/` || "";
+    return absBuildPath + artifactsDirName;
+}
+
+function makePathToArtifact(artifactName, config) {
+    return getArtifactsDirectory(config) + artifactName;
+}
+
+module.exports = {
+    getArtifactsDirectory,
+    makePathToArtifact,
+};

--- a/webpack/profiles/dev.js
+++ b/webpack/profiles/dev.js
@@ -4,6 +4,7 @@ const Webpack = require("webpack");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const configValidator = require("../../config/validator");
+const { makePathToArtifact } = require("../../config/helpers");
 
 function makeConfig(projectConfig, profileName) {
     const profileVariables = projectConfig.profiles[profileName];
@@ -22,12 +23,12 @@ function makeConfig(projectConfig, profileName) {
             tsconfig: path.resolve(projectRoot, "tsconfig.json"),
         }),
         new ExtractTextPlugin({
-            filename: `${profileName}.[name].bundle.css`,
+            filename: makePathToArtifact(`${profileName}.[name].bundle.css`, projectConfig),
             allChunks: true,
         }),
         new HtmlWebpackPlugin(htmlWebpackOptions),
         new Webpack.SourceMapDevToolPlugin({
-            filename: `${profileName}.[name].js.map`,
+            filename: makePathToArtifact(`${profileName}.[name].js.map`, projectConfig),
             exclude: [/vendor/, /.css/],
         }),
         new Webpack.DefinePlugin({
@@ -47,8 +48,8 @@ function makeConfig(projectConfig, profileName) {
     return {
         webpackDevtool: "eval-source-map",
         webpackOutputSettings: {
-            filename: `${profileName}.[name].bundle.js`,
-            chunkFilename: `${profileName}.chunk.[name].js`,
+            filename: makePathToArtifact(`${profileName}.[name].bundle.js`, projectConfig),
+            chunkFilename: makePathToArtifact(`${profileName}.chunk.[name].js`, projectConfig),
         },
         // WARNING! Be careful, this object overrides the default plugins section
         // so don't put the plugins to the base config

--- a/webpack/profiles/production.js
+++ b/webpack/profiles/production.js
@@ -7,11 +7,10 @@ const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
 const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const configValidator = require("../../config/validator");
+const { getArtifactsDirectory, makePathToArtifact } = require("../../config/helpers");
 
 function makeConfig(projectConfig, profileName) {
     const profileVariables = projectConfig.profiles[profileName];
-    const { buildPath } = projectConfig;
-
 
     let additionalBundles = ["runtime"];
     if (configValidator.vendor(projectConfig.vendorContents)) {
@@ -31,8 +30,8 @@ function makeConfig(projectConfig, profileName) {
     return {
         webpackDevtool: "source-map",
         webpackOutputSettings: {
-            filename: "[name].[chunkhash].bundle.js",
-            chunkFilename: "[name].[chunkhash].js",
+            filename: makePathToArtifact("[name].[chunkhash].bundle.js", projectConfig),
+            chunkFilename: makePathToArtifact("[name].[chunkhash].js", projectConfig),
         },
         // WARNING! Be careful, this object overrides the default plugins section
         // so don't put the plugins to the base config
@@ -40,7 +39,7 @@ function makeConfig(projectConfig, profileName) {
             new Webpack.HashedModuleIdsPlugin(),
             new WebpackChunkHash(),
             new ChunkManifestPlugin({
-                filename: "webpack-manifest.json",
+                filename: makePathToArtifact("webpack-manifest.json", projectConfig),
                 manifestVariable: "webpackManifest",
                 inlineManifest: true,
             }),
@@ -50,7 +49,7 @@ function makeConfig(projectConfig, profileName) {
             }),
             new Webpack.optimize.ModuleConcatenationPlugin(),
             new ExtractTextPlugin({
-                filename: "[name].[chunkhash].bundle.css",
+                filename: makePathToArtifact("[name].[chunkhash].bundle.css", projectConfig),
                 allChunks: true,
             }),
             new HtmlWebpackPlugin(htmlWebpackOptions),
@@ -64,8 +63,9 @@ function makeConfig(projectConfig, profileName) {
             new Webpack.DefinePlugin({
                 "process.env.NODE_ENV": JSON.stringify(profileName),
             }),
-            new CleanWebpackPlugin(buildPath, {
+            new CleanWebpackPlugin(getArtifactsDirectory(projectConfig), {
                 allowExternal: true,
+                verbose: true,
             }),
         ],
     };

--- a/webpack/profiles/production.js
+++ b/webpack/profiles/production.js
@@ -63,7 +63,7 @@ function makeConfig(projectConfig, profileName) {
             new Webpack.DefinePlugin({
                 "process.env.NODE_ENV": JSON.stringify(profileName),
             }),
-            new CleanWebpackPlugin(getArtifactsDirectory(projectConfig), {
+            new CleanWebpackPlugin(getArtifactsDirectory(projectConfig, true), {
                 allowExternal: true,
                 verbose: true,
             }),

--- a/webpack/profiles/test.js
+++ b/webpack/profiles/test.js
@@ -3,11 +3,12 @@ const environment = require("../../environment");
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const Webpack = require("webpack");
+const { makePathToArtifact } = require("../../config/helpers");
 
 function makePlugins(projectConfig, profileName) {
     const plugins = [
         new ExtractTextPlugin({
-            filename: "test/[name].bundle.css",
+            filename: makePathToArtifact("test/[name].bundle.css", projectConfig),
             allChunks: true,
         }),
         new Webpack.DefinePlugin({
@@ -30,8 +31,8 @@ function makeConfig(projectConfig) {
     return {
         webpackDevtool: "eval-source-map",
         webpackOutputSettings: {
-            filename: "test/[name].bundle.js",
-            chunkFilename: "[name].js",
+            filename: makePathToArtifact("test/[name].bundle.js", projectConfig),
+            chunkFilename: makePathToArtifact("[name].js", projectConfig),
         },
         // WARNING! Be careful, this object overrides the default plugins section
         // so don't put the plugins to the base config


### PR DESCRIPTION
Fixes #44 but in a slightly different way

Index.html always compiles to the `buildPath` dir, but you can move other files (js, css, images) to the subdirectory

It's really useful if you're working on the legacy project and stores your compiled sources in the public directory which has a lot of old files and you don't want to spoil this directory with your compiled files

You can enable this behavior by adding the `moveBuildArtifactsToSubfolder` field to the config