### PR TITLE
Add ability to configure plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,19 @@ module.exports = {
     //You can specify the path to your custom lint config if the default config doesn't fit your needs
     tsLintConfigPath: "",
     styleLintConfigPath: "",
-    devServer: {
-        // Here you can override DevServer's settings.
-        // FFBT proxies this object directly to the Webpack config
-        // More info: https://webpack.js.org/configuration/dev-server
-    },
-    moveBuildArtifactsToSubfolder: "build" // you can move your compiled js, css and images to the subdirectory
+    moveBuildArtifactsToSubfolder: "build", // you can move your compiled js, css and images to the subdirectory
+    webpackPlugins: {
+        // You can override settings for HTMLWebpackPlugin and WebpackDevServer 
+        // See docs for corresponding plugin for more info
+        // https://github.com/jantimon/html-webpack-plugin
+        // https://webpack.js.org/configuration/dev-server
+        htmlWebpackPlugin: {
+            inject: false,
+        },
+        devServer: {
+            port: 9999,
+        }
+    }
 };
 ```
 

--- a/config/default.js
+++ b/config/default.js
@@ -6,4 +6,5 @@ module.exports = {
     htmlBaseRoot: "/",
     buildPath: "dist",
     profiles: {},
+    webpackPlugins: {},
 };

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const chalk = require("chalk");
 const fs = require("fs");
 const constants = require("./constants");
 
@@ -18,7 +19,13 @@ function getLocalNodeModulesPath() {
     return path.resolve(__dirname, "node_modules");
 }
 
+function printDeprecationWarning(deprecatedName, newName) {
+    // eslint-disable-next-line no-console
+    console.warn(chalk.red(`WARN: ${deprecatedName} is deprecated. Use ${newName} instead`));
+}
+
 module.exports = {
     locateEntrypoint,
     getLocalNodeModulesPath,
+    printDeprecationWarning,
 };

--- a/webpack/config-generator.js
+++ b/webpack/config-generator.js
@@ -80,9 +80,14 @@ class WebpackConfigGenerator {
             },
         };
 
+        if (this.projectSettings.devServer) {
+            utils.printDeprecationWarning("devServer config value", "webpackPlugins.devServer");
+        }
+
         webpackConfig.devServer = {
             ...defaultDevServerConfig,
             ...this.projectSettings.devServer,
+            ...this.projectSettings.webpackPlugins.devServer,
         };
 
         if (env.analyzeModeEnabled()) {

--- a/webpack/profiles/dev.js
+++ b/webpack/profiles/dev.js
@@ -10,13 +10,13 @@ function makeConfig(projectConfig, profileName) {
     const profileVariables = projectConfig.profiles[profileName];
     const { projectRoot } = projectConfig;
 
-    const htmlWebpackOptions = {
+    const htmlWebpackOptions = Object.assign({
         inject: "body",
         hash: true,
         template: "index.ejs",
         profileVariables,
         envName: profileName,
-    };
+    }, projectConfig.webpackPlugins.htmlWebpackPlugin);
 
     const plugins = [
         new ForkTsCheckerWebpackPlugin({


### PR DESCRIPTION
Now users can configure webpack plugins via webpackPlugins field in config.
You can configure HTMLWebpackPlugin and WebpackDevServer
Later we'll add more plugins

config.devServer is deprecated, use config.webpackPlugins.devServer instead