### PR TITLE
Allow to setup custom sourcemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ CLI utility for compiling, testing and linting your TypeScript code.
 module.exports = {
     profiles: {
         dev: {
-            // custom variables for index.html in DEV profile
+            // You can set variables which will be available in index.ejs template
+            myVariable: 123,
+            // Also you can override some webpack settings. Now only source map type is supported
+            sourceMapType: "inline-source-map",
         },
         production: {
             // custom variables for index.html in PRODUCTION profile
@@ -40,7 +43,6 @@ module.exports = {
         // list of absolute paths
     ],
     buildPath: "./public/build", // path to your dist directory
-
     //You can specify the path to your custom lint config if the default config doesn't fit your needs
     tsLintConfigPath: "",
     styleLintConfigPath: "",

--- a/config/default-profile.js
+++ b/config/default-profile.js
@@ -1,0 +1,8 @@
+module.exports = {
+    dev: {
+        sourceMapType: "(none)",
+    },
+    production: {
+        sourceMapType: "nosources-source-map",
+    },
+};

--- a/config/helpers.js
+++ b/config/helpers.js
@@ -1,3 +1,5 @@
+const defaultProfileConfig = require("./default-profile");
+
 function getArtifactsDirectory(config, absolute = false) {
     const absBuildPath = absolute
         ? `${config.buildPath}/`
@@ -14,7 +16,19 @@ function makePathToArtifact(artifactName, config) {
     return getArtifactsDirectory(config) + artifactName;
 }
 
+function getProfileVariables(profileName, projectConfig) {
+    const variables = projectConfig.profiles[profileName];
+    const defaultVariables = defaultProfileConfig[profileName];
+
+    if (!variables) {
+        throw new Error(`Can't find profile '${profileName}'`);
+    }
+
+    return Object.assign({}, defaultVariables, variables);
+}
+
 module.exports = {
     getArtifactsDirectory,
     makePathToArtifact,
+    getProfileVariables,
 };

--- a/webpack/profiles/dev.js
+++ b/webpack/profiles/dev.js
@@ -4,10 +4,10 @@ const Webpack = require("webpack");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const configValidator = require("../../config/validator");
-const { makePathToArtifact } = require("../../config/helpers");
+const { makePathToArtifact, getProfileVariables } = require("../../config/helpers");
 
 function makeConfig(projectConfig, profileName) {
-    const profileVariables = projectConfig.profiles[profileName];
+    const profileVariables = getProfileVariables(profileName, projectConfig);
     const { projectRoot } = projectConfig;
 
     const htmlWebpackOptions = Object.assign({
@@ -46,7 +46,7 @@ function makeConfig(projectConfig, profileName) {
     }
 
     return {
-        webpackDevtool: "inline-source-map",
+        webpackDevtool: profileVariables.sourceMapType,
         webpackOutputSettings: {
             filename: makePathToArtifact(`${profileName}.[name].bundle.js`, projectConfig),
             chunkFilename: makePathToArtifact(`${profileName}.chunk.[name].js`, projectConfig),

--- a/webpack/profiles/production.js
+++ b/webpack/profiles/production.js
@@ -4,10 +4,10 @@ const Webpack = require("webpack");
 const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const configValidator = require("../../config/validator");
-const { getArtifactsDirectory, makePathToArtifact } = require("../../config/helpers");
+const { getArtifactsDirectory, makePathToArtifact, getProfileVariables } = require("../../config/helpers");
 
 function makeConfig(projectConfig, profileName) {
-    const profileVariables = projectConfig.profiles[profileName];
+    const profileVariables = getProfileVariables(profileName, projectConfig);
 
     let additionalBundles = ["runtime"];
     if (configValidator.vendor(projectConfig.vendorContents)) {
@@ -25,7 +25,7 @@ function makeConfig(projectConfig, profileName) {
     }, projectConfig.webpackPlugins.htmlWebpackPlugin);
 
     return {
-        webpackDevtool: "cheap-module-source-map",
+        webpackDevtool: profileVariables.sourceMapType,
         webpackOutputSettings: {
             filename: makePathToArtifact("[name].[chunkhash].bundle.js", projectConfig),
             chunkFilename: makePathToArtifact("[name].[chunkhash].js", projectConfig),


### PR DESCRIPTION
Fixes #155 

Now you can change the source map type for certain profile.
You can set in in your ffbt-config.js in profiles section

```
{
    profiles: {
        dev: {
            sourceMapType: 'inline-source-map'
        }
    }
}
```

*Breaking changes:*
I've changed default source maps types

Before:
- dev: `inline-source-map`
- prod: `cheap-module-source-map`

After:
- dev: `(none)` (use sourcemap provided by TS compiler)
- prod: `nosources-source-map` (don't expose source code, show only file name and line number)